### PR TITLE
Support for Magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
     }
   ],
   "require": {
-    "magento/module-payment": "100.0.*"
+    "magento/module-payment": "100.2.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.1.0",
-    "squizlabs/php_codesniffer": "1.5.3",
+    "phpunit/phpunit": "^6.2.4",
+    "squizlabs/php_codesniffer": "^3.0.1",
     "phpmd/phpmd": "@stable",
-    "pdepend/pdepend": "2.2.2",
-    "sebastian/phpcpd": "2.0.0",
-    "zendframework/zend-http": "~2.4.6",
+    "pdepend/pdepend": "^2.5.0",
+    "sebastian/phpcpd": "^2.0.0",
+    "zendframework/zend-http": "~2.7.0",
     "phing/phing": "@stable",
     "satooshi/php-coveralls": "@stable",
-    "magento/module-offline-payments": "100.0.*"
+    "magento/module-offline-payments": "100.2.*"
   },
   "license": "MIT",
   "keywords": [

--- a/tests/Unit/Model/Entity/Attribute/Source/PaymentMethodsTest.php
+++ b/tests/Unit/Model/Entity/Attribute/Source/PaymentMethodsTest.php
@@ -7,9 +7,9 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Payment\Helper\Data;
 use Magento\Payment\Model\MethodInterface;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PaymentMethodsTest extends PHPUnit_Framework_TestCase
+class PaymentMethodsTest extends TestCase
 {
     /**
      * @var PaymentMethods

--- a/tests/Unit/Model/Filter/CustomerTest.php
+++ b/tests/Unit/Model/Filter/CustomerTest.php
@@ -6,13 +6,13 @@ use DR\PaymentMethodFilter\Model\Filter\Customer as CustomerFilter;
 use Magento\Framework\DataObject;
 use Magento\Quote\Api\Data\CartInterface;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
 use Magento\OfflinePayments\Model\Cashondelivery;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Api\AttributeInterface;
+use PHPUnit\Framework\TestCase;
 
-class CustomerTest extends PHPUnit_Framework_TestCase
+class CustomerTest extends TestCase
 {
     /**
      * @var Cashondelivery|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Unit/Model/Filter/GuestTest.php
+++ b/tests/Unit/Model/Filter/GuestTest.php
@@ -10,9 +10,9 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\OfflinePayments\Model\Cashondelivery;
 use Magento\Quote\Api\Data\CartInterface;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class GuestTest extends PHPUnit_Framework_TestCase
+class GuestTest extends TestCase
 {
     /**
      * @var Cashondelivery|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Unit/Model/Filter/QuoteContentTest.php
+++ b/tests/Unit/Model/Filter/QuoteContentTest.php
@@ -9,11 +9,11 @@ use Magento\Framework\DataObject;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote\Item;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
 use Magento\OfflinePayments\Model\Cashondelivery;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
 
-class QuoteContentTest extends PHPUnit_Framework_TestCase
+class QuoteContentTest extends TestCase
 {
     /**
      * @var Cashondelivery|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Unit/Observer/ExcludeDisallowedPaymentMethodTest.php
+++ b/tests/Unit/Observer/ExcludeDisallowedPaymentMethodTest.php
@@ -14,9 +14,9 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\OfflinePayments\Model\Cashondelivery;
 use Magento\Quote\Model\Quote;
 use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ExcludeDisallowedPaymentMethodTest extends PHPUnit_Framework_TestCase
+class ExcludeDisallowedPaymentMethodTest extends TestCase
 {
     /**
      * @var DataObject


### PR DESCRIPTION
- Changed unit tests so they work with PHPunit v6
- Added support for Magento 2.2
- Dropped support for Magento 2.1/2.0 because fo the PHPUnit 6 unit tests.